### PR TITLE
Use imports-loader to prevent the cssfilter and xss modules from setting global vars

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "@types/jest": "^24.0.0",
+    "imports-loader": "^0.8.0",
     "jest": "^23.6.0",
     "rimraf": "^2.6.2",
     "ts-jest": "^24.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,10 @@ module.exports = (env, argv) => {
           test: /\.tsx?$/,
           use: 'ts-loader',
           exclude: /node_modules/
+        },
+        {
+          test: [require.resolve('cssfilter'), require.resolve('xss')],
+          use: 'imports-loader?window=>undefined'
         }
       ]
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1843,6 +1843,14 @@ import-local@^2.0.0:
     pkg-dir "^3.0.0"
     resolve-cwd "^2.0.0"
 
+imports-loader@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/imports-loader/-/imports-loader-0.8.0.tgz#030ea51b8ca05977c40a3abfd9b4088fe0be9a69"
+  integrity sha512-kXWL7Scp8KQ4552ZcdVTeaQCZSLW+e6nJfp3cwUMB673T7Hr98Xjx5JK+ql7ADlJUvj1JS5O01RLbKoutN5QDQ==
+  dependencies:
+    loader-utils "^1.0.2"
+    source-map "^0.6.1"
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"


### PR DESCRIPTION
Reference:
- https://github.com/leizongmin/js-xss/blob/master/lib/index.js#L31
- https://github.com/leizongmin/js-css-filter/blob/master/lib/index.js#L31