### PR TITLE
Add support for running inside a Worker

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,6 +47,7 @@ module.exports = (env, argv) => {
         argv.mode === 'production' ? '.min' : ''
       }.js`,
       path: path.resolve(__dirname, 'dist/umd'),
+      globalObject: 'this',
       library: 'Sanitizer',
       libraryExport: 'Sanitizer',
       libraryTarget: 'umd'


### PR DESCRIPTION
Changes umd root to be `this` instead of `window`.