### PR TITLE
Updates to match the supported ArcGIS Online HTML.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ export class Sanitizer {
     audio: ["autoplay", "controls", "loop", "muted", "preload", "src"],
     span: ["style"],
     table: ["width", "height", "cellpadding", "cellspacing", "border", "style"],
-    div: ["style", "class"],
+    div: ["style", "align"],
     font: ["size", "color", "style"],
     tr: ["height", "valign", "align", "style"],
     td: [
@@ -82,6 +82,8 @@ export class Sanitizer {
     br: [],
     li: [],
     ul: [],
+    ol: [],
+    hr: [],
     tbody: []
   };
   public readonly arcgisFilterOptions: XSS.IFilterXSSOptions = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,7 @@ export class Sanitizer {
     strong: [],
     i: [],
     em: [],
+    u: [],
     br: [],
     li: [],
     ul: [],


### PR DESCRIPTION
**For Issues**
* https://github.com/Esri/arcgis-html-sanitizer/issues/28
* https://github.com/Esri/arcgis-html-sanitizer/issues/30

**Changes**
This pull request adds the following tags to the whitelist to match ArcGIS Online's supported HTML tags: `u`, `ol`, `hr`. This also updates the `div` tag attributes to `style` and `align` to match the ArcGIS Online supported attributes.