### PR TITLE
Fixes for allowed protocol validation.

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -260,6 +260,14 @@ describe('Sanitizer', () => {
       expect(sanitizer.sanitize(anchor)).toBe('<a href>Link</a>');
     });
 
+    // Check for caps and mixed case protocols
+    const capsHttps = `<a href="HTTPS://someurl.tld?param1=1">Link</a>`;
+    const capsTel = `<a href="tel:+1-111-111-1111">Tel</a>`;
+    const mixedHttp = `<a href="hTTp://someurl.tld?param1=1">Link</a>`;
+    expect(sanitizer.sanitize(capsHttps)).toBe(capsHttps);
+    expect(sanitizer.sanitize(capsTel)).toBe(capsTel);
+    expect(sanitizer.sanitize(mixedHttp)).toBe(mixedHttp);
+
     // Ensure we can still use "/" and "#" as anchor href values
     expect(sanitizer.sanitize(rootAnchor)).toBe(rootAnchor);
     expect(sanitizer.sanitize(hashAnchor)).toBe(hashAnchor);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -260,9 +260,15 @@ describe('Sanitizer', () => {
       expect(sanitizer.sanitize(anchor)).toBe('<a href>Link</a>');
     });
 
+    // Check for protocols that don't include //, such as tel or mailto
+    const tel = `<a href="tel:+1-111-111-1111">Tel</a>`;
+    const mailto = `<a href="mailto:someuser@someurl.tld">Email</a>`;
+    expect(sanitizer.sanitize(tel)).toBe(tel);
+    expect(sanitizer.sanitize(mailto)).toBe(mailto);
+
     // Check for caps and mixed case protocols
     const capsHttps = `<a href="HTTPS://someurl.tld?param1=1">Link</a>`;
-    const capsTel = `<a href="tel:+1-111-111-1111">Tel</a>`;
+    const capsTel = `<a href="TEL:+1-111-111-1111">Tel</a>`;
     const mixedHttp = `<a href="hTTp://someurl.tld?param1=1">Link</a>`;
     expect(sanitizer.sanitize(capsHttps)).toBe(capsHttps);
     expect(sanitizer.sanitize(capsTel)).toBe(capsTel);

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,13 +124,13 @@ export class Sanitizer {
       // take over safe attribute filtering for `a` tag `href` attribute only,
       // otherwise pass onto the default XSS.safeAttrValue
       if (tag === 'a' && name === 'href') {
-        const protocol = this._trim(value.substring(0, value.indexOf('://')));
+        const protocol = this._trim(value.substring(0, value.indexOf(':')));
         if (
           !(
             value === '/' ||
             value === '#' ||
             value[0] === '#' ||
-            this.allowedProtocols.indexOf(protocol) > -1
+            this.allowedProtocols.indexOf(protocol.toLowerCase()) > -1
           )
         ) {
           return '';


### PR DESCRIPTION
This PR addresses issues pointed out in #35.

### Changes
* Fix issue with caps or mixed case validation of allowed protocols.
* Fix issue with allowed protocol validation when protocol doesn't include '//', such as with `tel:` or `mailto:`.
* Added tests for these specific cases.