### PR TITLE
Enhancements for sanitizing URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ ArcGIS Online supported HTML specification. The sanitized string can be inserted
 into the `DOM` via a method like `element.innerHTML = sanitizedHtml`. However,
 you should never insert the sanitized string in the following scenarios:
 
-```
+```html
 <script>...NEVER PUT UNTRUSTED DATA HERE...</script>   Directly in a script
 <!--...NEVER PUT UNTRUSTED DATA HERE...-->             Inside an HTML comment
 <div ...NEVER PUT UNTRUSTED DATA HERE...=test />       In an attribute name
@@ -144,6 +144,29 @@ const sanitizedJSON = sanitizer.sanitize({
 // sanitizedJSON => {
 //  "sample": ["<img src=\"https://example.com/fake-image.jpg\" />"]
 // }
+```
+
+#### Sanitize URLs
+
+The ability to sanitize URL strings has been specifically broken out to a public
+method, `sanitizeUrl`. This can be very useful if you want to sanitize URLs
+according to the built-in rules, yet you don't want to necessarily extend the
+whitelist and implement custom filtering options to force sanitization of
+specific tag attributes.
+
+```js
+// Instantiate a new Sanitizer object
+const sanitizer = new Sanitizer();
+
+// Sanitize a URL with a valid protocol
+const supportedProtocol = sanitizer.sanitizeUrl("https://example.com/about/index.html");
+
+// supportedProtocol => "https://example.com/about/index.html"
+
+// Sanitize a URL with an invalid protocol
+const unsupportedProtocol = sanitizer.sanitizeUrl("smb://example.com/path/to/file.html");
+
+// unsupportedProtocol => ""
 ```
 
 #### Customizing Filter Options

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,20 +123,8 @@ export class Sanitizer {
     ): string => {
       // take over safe attribute filtering for `a` tag `href` attribute only,
       // otherwise pass onto the default XSS.safeAttrValue
-      if (tag === 'a' && name === 'href') {
-        const protocol = this._trim(value.substring(0, value.indexOf(':')));
-        if (
-          !(
-            value === '/' ||
-            value === '#' ||
-            value[0] === '#' ||
-            this.allowedProtocols.indexOf(protocol.toLowerCase()) > -1
-          )
-        ) {
-          return '';
-        } else {
-          return xss.escapeAttrValue(value);
-        }
+      if ((tag === 'a' && name === 'href') || (tag === 'img' && name === 'src')) {
+        return this.sanitizeUrl(value);
       }
       return xss.safeAttrValue(tag, name, value, cssFilter);
     }
@@ -200,6 +188,28 @@ export class Sanitizer {
         return this._iterateOverObject(value);
       default:
         return null;
+    }
+  }
+
+  /**
+   * Sanitizes a URL string following the allowed protocols and sanitization rules.
+   * 
+   * @param {string} value The URL to sanitize.
+   * @returns {string} The sanitized URL.
+   */
+  public sanitizeUrl(value: string): string {
+    const protocol = this._trim(value.substring(0, value.indexOf(':')));
+    if (
+      !(
+        value === '/' ||
+        value === '#' ||
+        value[0] === '#' ||
+        this.allowedProtocols.indexOf(protocol.toLowerCase()) > -1
+      )
+    ) {
+      return '';
+    } else {
+      return xss.escapeAttrValue(value);
     }
   }
 


### PR DESCRIPTION
#### Purpose
After some internal discussions, we identified a couple things that could be easily addressed to help developers using this library.

#### Issues addressed
The first issue identified was that as the `img` `src` attribute contains URLs like `a` `href` attributes, we should sanitize the URLs the same way we do for `a` `href`. This adds `img` `src` tag attribute to the built-in sanitization supporting our list of allowed protocols.

The second thing identified that we need to break out the URL sanitization into a public method to make it possible to sanitize URLs according to the rules, without necessarily needing to extend the whitelist and/or define custom filtering options to sanitize tag attributes containing URI values. This update adds a public `sanitizeUrl` method, which we then reuse in our custom filtering option that handles `a` `href` and `img` `src` parsing.

This update includes documentation and tests for the `sanitizeUrl` method as well as some cleanup to the tests for allowed protocols added in earlier enhancements.