### PR TITLE
Enhancement to sanitize `audio` and `video` `src` attributes.

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -248,16 +248,24 @@ describe('Sanitizer', () => {
     allowedProtocols.forEach((protocol: string) => {
       const anchor = `<a href="${protocol}://someurl.tld?param1=1&param2=2">Link</a>`;
       const image = `<img src="${protocol}://someurl.tld/path/to/image.svg">`;
+      const audio = `<audio src="${protocol}://someurl.tld/path/to/audio/file.mp3">`;
+      const video = `<video src="${protocol}://someurl.tld/path/to/video/file.mpeg">`;
       expect(sanitizer.sanitize(anchor)).toBe(anchor);
       expect(sanitizer.sanitize(image)).toBe(image);
+      expect(sanitizer.sanitize(audio)).toBe(audio);
+      expect(sanitizer.sanitize(video)).toBe(video);
     });
     // Ensure disallowed protocols are still disallowed and are sanitized
     const disallowedProtocols: string[] = ['ftp', 'smb'];
     disallowedProtocols.forEach((protocol: string) => {
       const anchor = `<a href="${protocol}://someurl.tld?param1=1&param2=2">Link</a>`;
       const image = `<img src="${protocol}://someurl.tld/path/to/image.svg">`;
+      const audio = `<audio src="${protocol}://someurl.tld/path/to/audio/file.mp3">`;
+      const video = `<video src="${protocol}://someurl.tld/path/to/video/file.mpeg">`;
       expect(sanitizer.sanitize(anchor)).toBe('<a href>Link</a>');
       expect(sanitizer.sanitize(image)).toBe('<img src>');
+      expect(sanitizer.sanitize(audio)).toBe('<audio src>');
+      expect(sanitizer.sanitize(video)).toBe('<video src>');
     });
 
     // Check for protocols that don't include //, such as tel or mailto
@@ -277,8 +285,12 @@ describe('Sanitizer', () => {
     [tel, mailto, capsHttps, capsTel, mixedHttp, root, hash, hashId].forEach((uri: string) => {
       const anchor = `<a href="${uri}">Link</a>`;
       const image = `<img src="${uri}">`;
+      const audio = `<audio src="${uri}">`;
+      const video = `<video src="${uri}">`;
       expect(sanitizer.sanitize(anchor)).toBe(anchor);
       expect(sanitizer.sanitize(image)).toBe(image);
+      expect(sanitizer.sanitize(audio)).toBe(audio);
+      expect(sanitizer.sanitize(video)).toBe(video);
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,9 +121,13 @@ export class Sanitizer {
       value: string,
       cssFilter: XSS.ICSSFilter
     ): string => {
-      // take over safe attribute filtering for `a` tag `href` attribute only,
-      // otherwise pass onto the default XSS.safeAttrValue
-      if ((tag === 'a' && name === 'href') || (tag === 'img' && name === 'src')) {
+      // Take over safe attribute filtering for `a` `href`, `img` `src`,
+      // `audio` `src`, and `video` `src` attributes, otherwise pass onto the
+      // default `XSS.safeAttrValue` method.
+      if (
+        (tag === 'a' && name === 'href') ||
+        ((tag === 'img' || tag === 'audio' || tag === 'video') && name === 'src')
+      ) {
         return this.sanitizeUrl(value);
       }
       return xss.safeAttrValue(tag, name, value, cssFilter);


### PR DESCRIPTION
#### Purpose
This brings the supported `audio` and `video` tag `src` attributes into line with `img` `src` and `a` `href` attributes as far as our sanitization rules go. Test cases have been extended to test these tag attributes as well.