### PR TITLE
Adds support for the HTML source tag.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,10 @@ export interface IValidationResponse {
   sanitized: any;
 }
 
+export interface IWhiteList extends XSS.IWhiteList {
+  source?: string[]
+}
+
 /**
  * The Sanitizer Class
  *
@@ -33,7 +37,7 @@ export interface IValidationResponse {
  */
 export class Sanitizer {
   // Supported HTML Spec: https://doc.arcgis.com/en/arcgis-online/reference/supported-html.htm
-  public readonly arcgisWhiteList: XSS.IWhiteList = {
+  public readonly arcgisWhiteList: IWhiteList = {
     a: ['href', 'target', 'style'],
     img: ['src', 'width', 'height', 'border', 'alt', 'style'],
     video: [
@@ -44,10 +48,10 @@ export class Sanitizer {
       'muted',
       'poster',
       'preload',
-      'src',
       'width'
     ],
-    audio: ['autoplay', 'controls', 'loop', 'muted', 'preload', 'src'],
+    audio: ['autoplay', 'controls', 'loop', 'muted', 'preload'],
+    source: ['media', 'src', 'type'],
     span: ['style'],
     table: ['width', 'height', 'cellpadding', 'cellspacing', 'border', 'style'],
     div: ['style', 'align'],
@@ -122,11 +126,11 @@ export class Sanitizer {
       cssFilter: XSS.ICSSFilter
     ): string => {
       // Take over safe attribute filtering for `a` `href`, `img` `src`,
-      // `audio` `src`, and `video` `src` attributes, otherwise pass onto the
+      // and `source` `src` attributes, otherwise pass onto the
       // default `XSS.safeAttrValue` method.
       if (
         (tag === 'a' && name === 'href') ||
-        ((tag === 'img' || tag === 'audio' || tag === 'video') && name === 'src')
+        ((tag === 'img' || tag === 'source') && name === 'src')
       ) {
         return this.sanitizeUrl(value);
       }


### PR DESCRIPTION
ArcGIS Online does not support the `src` attribute in the `audio` or `video` tags, and instead requires use of the nested `source` tag within `audio` and `video` tags.

This commit updates the whitelist to remove the `src` attribute from the `audio` and `video` tags, adds support for the `source` tag, and adds tests to validate these additions and removals.

Unsupported form:
`<audio src="http://mydomain.tld/path/to/audio/file.ext">`

Supported form:
`<audio><source src="http://mydomain.tld/path/to/audio/file.ext"></audio>`

Note that `XSS` by default doesn't list the `source` tag as one that can be whitelisted, which is why I've extended the `XSS.IWhitelist` to add support for the `source` tag directly.