### PR TITLE
Saniziting HTML attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,11 +213,11 @@ const styles = sanitizer.sanitizeHTMLAttribute(
 // styles => ""
 ```
 
-Optionally, a custom filter for style attributes can be provided as the final argument. Providing this filter opts out of the default JSXSS style attribute filter, so you are then responsible for sanitizing style attribute values manually (some protection against `url()` values is still provided).
+Optionally, a custom filter for style attributes can be provided as the final argument, which will be used in place of the default js-xss style attribute filter.
 ```js
 
 const styles = sanitizer.sanitizeHTMLAttribute('div', 'style', 'color:red;', { 
-  process: (value: string) => value.indexOf('color') !== -1 ? '' : /* additional filtering/sanitizing here */ 
+  process: (value: string) => value.indexOf('color') !== -1 ? '' : value /* or additional filtering here */ 
 });
 
 // styles => ""
@@ -227,7 +227,7 @@ const styles = sanitizer.sanitizeHTMLAttribute('div', 'style', 'color:red;', {
 
 #### Customizing Filter Options
 
-Override the default XSS filter options by passing a valid js-css options object as the first parameter of the constructor. Options available here: https://github.com/leizongmin/js-xss#custom-filter-rules.
+Override the default XSS filter options by passing a valid js-xss options object as the first parameter of the constructor. Options available here: https://github.com/leizongmin/js-xss#custom-filter-rules.
 
 You can also extend the default options instead of overriding them by passing `true` as the second parameter of the constructor. When extending
 the filter options `whiteList`, the attribute arrays will automatically

--- a/README.md
+++ b/README.md
@@ -181,6 +181,50 @@ const unsupportedProtocol = sanitizer.sanitizeUrl(
 // unsupportedProtocol => ""
 ```
 
+#### Sanitize HTML Attribute Values
+
+To prevent against XSS, untrusted data going into HTML attribute values need to be 
+[sanitized](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#rule-2-attribute-encode-before-inserting-untrusted-data-into-html-common-attributes), 
+including [`style` attribute values](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#rule-4-css-encode-and-strictly-validate-before-inserting-untrusted-data-into-html-style-property-values).
+The ability to sanitize HTML attribute values has been specifically broken out to a public
+method, `sanitizeHTMLAttribute`, specifying the tagname, attribute name, and value.
+
+```js
+// Instantiate a new Sanitizer object
+const sanitizer = new Sanitizer();
+
+// Sanitize a safe alt attribute value
+const unquotedAttribute = sanitizer.sanitizeHTMLAttribute('img', 'alt', 'A picture');
+
+// unquotedAttribute => "A picture"
+
+// Sanitize an unsafe alt attribute value
+const quotedAttribute = sanitizer.sanitizeHTMLAttribute('img', 'alt', '"A picture"');
+
+// quotedAttribute => "&quot;A picture&quot;"
+
+// Sanitize unsafe style attribute value
+const styles = sanitizer.sanitizeHTMLAttribute(
+  'div', 
+  'style', 
+  'background-image:url("javascript:alert(\"xss\")")'
+);  
+
+// styles => ""
+```
+
+Optionally, a custom filter for style attributes can be provided as the final argument. Providing this filter opts out of the default JSXSS style attribute filter, so you are then responsible for sanitizing style attribute values manually (some protection against `url()` values is still provided).
+```js
+
+const styles = sanitizer.sanitizeHTMLAttribute('div', 'style', 'color:red;', { 
+  process: (value: string) => value.indexOf('color') !== -1 ? '' : /* additional filtering/sanitizing here */ 
+});
+
+// styles => ""
+
+```
+
+
 #### Customizing Filter Options
 
 Override the default XSS filter options by passing a valid js-css options object as the first parameter of the constructor. Options available here: https://github.com/leizongmin/js-xss#custom-filter-rules.

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -443,7 +443,11 @@ describe("Sanitizer", () => {
     // src with javascript URL should be removed
     expect(anotherCustomSanitizer.sanitizeHTMLAttribute('img', 'src', 'javascript:alert("xss")')).toBe('');    
     // href with javascript URL should be removed
-    expect(anotherCustomSanitizer.sanitizeHTMLAttribute('a', 'href', 'javascript:alert("xss")')).toBe('');        
+    expect(anotherCustomSanitizer.sanitizeHTMLAttribute('a', 'href', 'javascript:alert("xss")')).toBe(''); 
+    // custom filter removes style value
+    expect(anotherCustomSanitizer.sanitizeHTMLAttribute('div', 'style', 'color:red;', { process: (value: string) => value.indexOf('color') !== -1 ? '' : value })).toBe('');                
+    // custom filter still disallows javascript URLs
+    expect(anotherCustomSanitizer.sanitizeHTMLAttribute('div', 'style', 'background-image:url("javascript:alert(\"xss\")"', { process: (value: string) => value })).toBe('');               
   });
 
   test("check for some of the allowed tags and attributes", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -231,6 +231,21 @@ export class Sanitizer {
   }
 
   /**
+   * Sanitizes an HTML attribute value.
+   *
+   * @param {string} tag The tagname of the HTML element.
+   * @param {string} attribute The attribute name of the HTML element.
+   * @param {string} value The raw value to be used for the HTML attribute value.
+   * @param {XSS.ICSSFilter} [cssFilter] The CSS filter to be used.
+   * @returns {string} The sanitized attribute value.
+   * @memberof Sanitizer
+   */
+  public sanitizeHTMLAttribute(tag: string, attribute: string, value: string, cssFilter?: XSS.ICSSFilter): string {
+    // @ts-ignore safeAttrValue does handle undefined cssFilter
+    return xss.safeAttrValue(tag, attribute, value, cssFilter);
+  }
+
+  /**
    * Checks if a value only contains valid HTML.
    *
    * @param {any} value The value to validate.

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,7 +144,7 @@ export class Sanitizer {
     }
   };
   public readonly xssFilterOptions: XSS.IFilterXSSOptions;
-  private _xssFilter: XSS.ICSSFilter;
+  private _xssFilter: xss.FilterXSS;  
 
   constructor(filterOptions?: XSS.IFilterXSSOptions, extendDefaults?: boolean) {
     let xssFilterOptions: XSS.IFilterXSSOptions;
@@ -240,7 +240,14 @@ export class Sanitizer {
    * @returns {string} The sanitized attribute value.
    * @memberof Sanitizer
    */
-  public sanitizeHTMLAttribute(tag: string, attribute: string, value: string, cssFilter?: XSS.ICSSFilter): string {
+  public sanitizeHTMLAttribute(tag: string, attribute: string, value: string, cssFilter?: XSS.ICSSFilter): string {    
+    // use the custom safeAttrValue function if provided
+    if (typeof this.xssFilterOptions.safeAttrValue === 'function') {      
+      // @ts-ignore safeAttrValue does handle undefined cssFilter
+      return this.xssFilterOptions.safeAttrValue(tag, attribute, value, cssFilter);
+    }
+
+    // otherwise use the default
     // @ts-ignore safeAttrValue does handle undefined cssFilter
     return xss.safeAttrValue(tag, attribute, value, cssFilter);
   }


### PR DESCRIPTION
## Overview
Data can now be sanitized before being put into HTML attribute values. Front-end frameworks like React have decent XSS protection for things injected as children elements, but not much protection for untrusted values being put into HTML attributes (like `alt` tag on image, `href` on anchor, `style` on div, `background` on body, etc).


## Details
* Wrapped `js-xss`'s `safeAttrValue()` with a new instance method -- `sanitizeHTMLAttribute()`, which takes in the same parameters. 
* `sanitizeHTMLAttribute()` uses the custom `safeAttrValue()` if one is provided to the `Sanitizer` constructor

## Changes
* Updated `this._xssFilter`'s type