### PR TITLE
Task: add font face attribute to whitelist.

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -469,6 +469,7 @@ describe("Sanitizer", () => {
     const stripVideoSrc = `<video controls src="http://someurl.tld/path/to/video/file.mpeg">`;
     const strippedAudioSrc = "<audio controls>";
     const strippedVideoSrc = "<video controls>";
+    const fontFace = `<font face="Arial">Text content</font>`;
 
     const sanitizer = new Sanitizer();
 
@@ -482,6 +483,7 @@ describe("Sanitizer", () => {
     expect(sanitizer.sanitize(stripAudioSrc)).toBe(strippedAudioSrc);
     expect(sanitizer.sanitize(video)).toBe(video);
     expect(sanitizer.sanitize(stripVideoSrc)).toBe(strippedVideoSrc);
+    expect(sanitizer.sanitize(fontFace)).toBe(fontFace);
   });
 
   test("trims a string", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ export class Sanitizer {
     span: ["style"],
     table: ["width", "height", "cellpadding", "cellspacing", "border", "style"],
     div: ["style", "align"],
-    font: ["size", "color", "style"],
+    font: ["size", "color", "style", "face"],
     tr: ["height", "valign", "align", "style"],
     td: [
       "height",


### PR DESCRIPTION
The font `face` attribute is supported on the Sharing API side. This is needed to support popups in the Map Viewers.