### PR TITLE
Add encoding methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ const styles = sanitizer.sanitizeHTMLAttribute('div', 'style', 'color:red;', {
 ```
 
 #### Encode HTML
-The `encodeHTML` method encodes a well-defined set of characters within an HTML string to their hexadecimal HTML entity codes to ensure safe display of the string to the end user. This merely encodes HTML tags for as text in other HTML, it does not sanitize the string to prevent XSS. If you are looking to sanitize, use the `sanitize` method instead.
+The `encodeHTML` method encodes a well-defined set of characters within an HTML string to their hexadecimal HTML entity codes to ensure safe display of the string to the end user. This encodes HTML tags for display as text within an HTML page, it does not sanitize the string to prevent XSS. If you are looking to sanitize, use the `sanitize` method instead.
 
 * `&` &rarr; `&#x38;`
 * `<` &rarr; `&#x3C;`

--- a/README.md
+++ b/README.md
@@ -224,6 +224,35 @@ const styles = sanitizer.sanitizeHTMLAttribute('div', 'style', 'color:red;', {
 
 ```
 
+#### Encode HTML Entities
+The `encodeHTMLEntities` method encodes a well-defined set of characters within an HTML string to their hexadecimal HTML entity codes to ensure safe display of the string to the end user.
+
+* `&` &rarr; `&#x38;`
+* `<` &rarr; `&#x3C;`
+* `>` &rarr; `&#x3E;`
+* `"` &rarr; `&#x22;`
+* `'` &rarr; `&#x27;`
+* `/` &rarr; `&#x2F;`
+
+
+```js
+const sanitizer = new Sanitizer();
+
+const input = `<a href="javascript:alert(document.cookies)">a link</a>`;
+sanitizer.encodeHTMLEntities(input);
+// => "&#x3C;a href=&#x22;javascript:alert(document.cookies)&#x22;&#x3E;a link&#x3C;&#x2F;a&#x3E;"
+```
+
+#### Encode Attribute Values
+The `encodeAttrValue` method encodes all non-alphanumeric ASCII characters to their hexadecimal HTML entity code to ensure safe use as an HTML attribute.
+
+```js
+const sanitizer = new Sanitizer();
+
+const input = "javascript:alert(document.cookies)";
+sanitizer.encodeAttrValue(input);
+// => "javascript&#x3a;alert&#x28;document&#x2e;cookie&#x29;"
+```
 
 #### Customizing Filter Options
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ sanitizer.encodeHTML(input);
 ```
 
 #### Encode Attribute Values
-The `encodeAttrValue` method encodes all non-alphanumeric ASCII characters to their hexadecimal HTML entity code to ensure safe use as an HTML attribute.
+The `encodeAttrValue` method encodes all non-alphanumeric ASCII characters to their hexadecimal HTML entity code to ensure safe use as an HTML attribute. This method only encodes characters. It does not directly sanitize the string to remove XSS. If you are looking to sanitize your string, use the `sanitizeHTMLAttribute` method instead.
 
 ```js
 const sanitizer = new Sanitizer();

--- a/README.md
+++ b/README.md
@@ -224,8 +224,8 @@ const styles = sanitizer.sanitizeHTMLAttribute('div', 'style', 'color:red;', {
 
 ```
 
-#### Encode HTML Entities
-The `encodeHTMLEntities` method encodes a well-defined set of characters within an HTML string to their hexadecimal HTML entity codes to ensure safe display of the string to the end user.
+#### Encode HTML
+The `encodeHTML` method encodes a well-defined set of characters within an HTML string to their hexadecimal HTML entity codes to ensure safe display of the string to the end user. This merely encodes HTML tags for as text in other HTML, it does not sanitize the string to prevent XSS. If you are looking to sanitize, use the `sanitize` method instead.
 
 * `&` &rarr; `&#x38;`
 * `<` &rarr; `&#x3C;`
@@ -239,7 +239,7 @@ The `encodeHTMLEntities` method encodes a well-defined set of characters within 
 const sanitizer = new Sanitizer();
 
 const input = `<a href="javascript:alert(document.cookies)">a link</a>`;
-sanitizer.encodeHTMLEntities(input);
+sanitizer.encodeHTML(input);
 // => "&#x3C;a href=&#x22;javascript:alert(document.cookies)&#x22;&#x3E;a link&#x3C;&#x2F;a&#x3E;"
 ```
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -499,13 +499,13 @@ describe("Sanitizer", () => {
     expect(_trim(trimmedString)).toBe(trimmedString);
   });
 
-  test("encodes HTML entities", () => {
+  test("encodes HTML", () => {
     const sanitizer = new Sanitizer();
     const html = `<a href="https://someurl.tld">Link '1'</a> &middot; <a href="https://someurl.tld/path1">Link '2'</a>`;
     const encoded = `&#x3C;a href=&#x22;https:&#x2F;&#x2F;someurl.tld&#x22;&#x3E;Link &#x27;1&#x27;&#x3C;&#x2F;a&#x3E; &#x38;middot; &#x3C;a href=&#x22;https:&#x2F;&#x2F;someurl.tld&#x2F;path1&#x22;&#x3E;Link &#x27;2&#x27;&#x3C;&#x2F;a&#x3E;`;
     const text = "This is plain text with no encoding necessary.";
-    expect(sanitizer.encodeHTMLEntities(html)).toBe(encoded);
-    expect(sanitizer.encodeHTMLEntities(text)).toBe(text);
+    expect(sanitizer.encodeHTML(html)).toBe(encoded);
+    expect(sanitizer.encodeHTML(text)).toBe(text);
   });
 
   test("encodes HTML attribute values", () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -498,4 +498,26 @@ describe("Sanitizer", () => {
     expect(_trim(str)).toBe(trimmedString);
     expect(_trim(trimmedString)).toBe(trimmedString);
   });
+
+  test("encodes HTML entities", () => {
+    const sanitizer = new Sanitizer();
+    const html = `<a href="https://someurl.tld">Link '1'</a> &middot; <a href="https://someurl.tld/path1">Link '2'</a>`;
+    const encoded = `&#x3C;a href=&#x22;https:&#x2F;&#x2F;someurl.tld&#x22;&#x3E;Link &#x27;1&#x27;&#x3C;&#x2F;a&#x3E; &#x38;middot; &#x3C;a href=&#x22;https:&#x2F;&#x2F;someurl.tld&#x2F;path1&#x22;&#x3E;Link &#x27;2&#x27;&#x3C;&#x2F;a&#x3E;`;
+    const text = "This is plain text with no encoding necessary.";
+    expect(sanitizer.encodeHTMLEntities(html)).toBe(encoded);
+    expect(sanitizer.encodeHTMLEntities(text)).toBe(text);
+  });
+
+  test("encodes HTML attribute values", () => {
+    const sanitizer = new Sanitizer();
+    const url = "https://someurl.tld/path1?f=json&ts=123002398483";
+    const alert = "javascript:alert(document.cookie)";
+    const encodedUrl =
+      "https&#x3a;&#x2f;&#x2f;someurl&#x2e;tld&#x2f;path1&#x3f;f&#x3d;json&#x26;ts&#x3d;123002398483";
+    const encodedAlert =
+      "javascript&#x3a;alert&#x28;document&#x2e;cookie&#x29;";
+    expect(sanitizer.encodeAttrValue(url)).toBe(encodedUrl);
+    expect(sanitizer.encodeAttrValue(alert)).toBe(encodedAlert);
+  });
+
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -552,6 +552,10 @@ describe("Sanitizer", () => {
       }
     }
 
+    // Ensure " and ' are encoded correctly
+    expect(sanitizer.encodeAttrValue('"')).toBe("&#x22;");
+    expect(sanitizer.encodeAttrValue("'")).toBe("&#x27;");
+
     // Ensure expected encoding happens for a sample URL
     expect(sanitizer.encodeAttrValue(url)).toBe(encodedUrl);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -275,7 +275,7 @@ export class Sanitizer {
         tag,
         attribute,
         value,
-        // @ts-ignore safeAttrValue does handle undefined cssFilter
+        // @ts-expect-error safeAttrValue does handle undefined cssFilter
         cssFilter
       );
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,7 @@ export class Sanitizer {
       "rowspan",
       "style",
       "valign",
-      "width"
+      "width",
     ],
     th: [
       "align",
@@ -95,7 +95,7 @@ export class Sanitizer {
       "rowspan",
       "style",
       "valign",
-      "width"
+      "width",
     ],
     u: [],
     ul: [],
@@ -107,8 +107,8 @@ export class Sanitizer {
       "muted",
       "poster",
       "preload",
-      "width"
-    ]
+      "width",
+    ],
   };
   public readonly allowedProtocols: string[] = [
     "http",
@@ -136,7 +136,7 @@ export class Sanitizer {
     "awb",
     "awbs",
     "gropen",
-    "radarscope"
+    "radarscope",
   ];
   public readonly arcgisFilterOptions: XSS.IFilterXSSOptions = {
     allowCommentTag: true,
@@ -156,7 +156,7 @@ export class Sanitizer {
         return this.sanitizeUrl(value);
       }
       return xss.safeAttrValue(tag, name, value, cssFilter);
-    }
+    },
   };
   public readonly xssFilterOptions: XSS.IFilterXSSOptions;
   private _xssFilter: xss.FilterXSS;
@@ -166,7 +166,7 @@ export class Sanitizer {
     ">": "&#x3E;",
     '"': "&#x22;",
     "'": "&#x27;",
-    "/": "&#x2F;"
+    "/": "&#x2F;",
   };
 
   constructor(filterOptions?: XSS.IFilterXSSOptions, extendDefaults?: boolean) {
@@ -178,12 +178,12 @@ export class Sanitizer {
     } else if (filterOptions && extendDefaults) {
       // Extend the defaults
       xssFilterOptions = Object.create(this.arcgisFilterOptions);
-      Object.keys(filterOptions).forEach(key => {
+      Object.keys(filterOptions).forEach((key) => {
         if (key === "whiteList") {
           // Extend the whitelist by concatenating arrays
           xssFilterOptions.whiteList = this._extendObjectOfArrays([
             this.arcgisWhiteList,
-            filterOptions.whiteList || {}
+            filterOptions.whiteList || {},
           ]);
         } else {
           xssFilterOptions[key] = filterOptions[key];
@@ -300,7 +300,7 @@ export class Sanitizer {
 
     return {
       isValid: value === sanitized,
-      sanitized
+      sanitized,
     };
   }
 
@@ -312,7 +312,7 @@ export class Sanitizer {
    * @returns {string} The encoded string value.
    * @memberof Sanitizer
    */
-  public encodeHTMLEntities(value: string): string {
+  public encodeHTML(value: string): string {
     return String(value).replace(/[&<>"'\/]/g, (s) => {
       return this._entityMap[s];
     });
@@ -328,7 +328,7 @@ export class Sanitizer {
    */
   public encodeAttrValue(value: string): string {
     const alphanumericRE = /^[a-zA-Z0-9]$/;
-    return String(value).replace(/[\x00-\x7F]/g, (c, idx) => {
+    return String(value).replace(/[\x00-\xFF]/g, (c, idx) => {
       return !alphanumericRE.test(c)
         ? `&#x${Number(value.charCodeAt(idx)).toString(16)};`
         : c;
@@ -349,8 +349,8 @@ export class Sanitizer {
   private _extendObjectOfArrays(objects: {}[]): {} {
     const finalObj = {};
 
-    objects.forEach(obj => {
-      Object.keys(obj).forEach(key => {
+    objects.forEach((obj) => {
+      Object.keys(obj).forEach((key) => {
         if (Array.isArray(obj[key]) && Array.isArray(finalObj[key])) {
           finalObj[key] = finalObj[key].concat(obj[key]);
         } else {


### PR DESCRIPTION
### Changes

**feat: Add `encodeHTML` and `encodeAttrValue` methods.**

The `encodeHTML` method encodes a defined set of characters found in HTML strings to their hexadecimal HTML entity code. The set of character mappings follows:

* `&` &rarr; `&#x38;`
* `<` &rarr; `&#x3C;`
* `>` &rarr; `&#x3E;`
* `"` &rarr; `&#x22;`
* `'` &rarr; `&#x27;`
* `/` &rarr; `&#x2F;`

The `encodeAttrValue` method is for encoding strings meant for use as HTML tag attribute values. It encodes all non-alphanumeric ASCII values to their hexadecimal HTML entity code, e.g., `&x#HH;` where `HH` is the hexadecimal value.