### PR TITLE
Add option to allow URLs without protocols

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -368,7 +368,10 @@ describe("Sanitizer", () => {
     const hash = "#";
     const hashId = "#test";
 
-    [tel, mailto, capsHttps, capsTel, mixedHttp, root, hash, hashId].forEach(
+    // Accept URLs without a protocol
+    const withoutProtocol = "google.com";
+
+    [tel, mailto, capsHttps, capsTel, mixedHttp, root, hash, hashId, withoutProtocol].forEach(
       (url: string) => {
         expect(sanitizer.sanitizeUrl(url)).toBe(url);
       }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -371,11 +371,12 @@ describe("Sanitizer", () => {
     // Accept URLs without a protocol
     const withoutProtocol = "google.com";
 
-    [tel, mailto, capsHttps, capsTel, mixedHttp, root, hash, hashId, withoutProtocol].forEach(
+    [tel, mailto, capsHttps, capsTel, mixedHttp, root, hash, hashId].forEach(
       (url: string) => {
         expect(sanitizer.sanitizeUrl(url)).toBe(url);
       }
     );
+    expect(sanitizer.sanitizeUrl(withoutProtocol, { isProtocolRequired: false })).toBe(withoutProtocol);
   });
   
   test('sanitizes HTML attributes', () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -376,7 +376,8 @@ describe("Sanitizer", () => {
         expect(sanitizer.sanitizeUrl(url)).toBe(url);
       }
     );
-    expect(sanitizer.sanitizeUrl(withoutProtocol, { isProtocolRequired: false })).toBe(withoutProtocol);
+    expect(sanitizer.sanitizeUrl(withoutProtocol, { isProtocolRequired: false })).toBe(`https://${withoutProtocol}`);
+    expect(sanitizer.sanitizeUrl(withoutProtocol, { isProtocolRequired: true })).toBe('');
   });
   
   test('sanitizes HTML attributes', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -229,15 +229,18 @@ export class Sanitizer {
    * @param {string} value The URL to sanitize.
    * @returns {string} The sanitized URL.
    */
-  public sanitizeUrl(value: string): string {
+  public sanitizeUrl(value: string, options?: {
+    /** Whether a protocol must exist on the URL for it to be considered valid. Defaults to `true`. */
+    isProtocolRequired?: boolean;
+  }): string {
+    const { isProtocolRequired = true } = options ?? {};
     const protocol = this._trim(value.substring(0, value.indexOf(":")));
+    const isInvalidProtocol = isProtocolRequired && this.allowedProtocols.indexOf(protocol.toLowerCase()) === -1;
     if (
-      !(
-        value === "/" ||
-        value === "#" ||
-        value[0] === "#" ||
-        this.allowedProtocols.indexOf(protocol.toLowerCase()) > -1
-      )
+      value !== "/" &&
+      value !== "#" &&
+      value[0] !== "#" &&
+      isInvalidProtocol
     ) {
       return "";
     } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -235,13 +235,10 @@ export class Sanitizer {
   }): string {
     const { isProtocolRequired = true } = options ?? {};
     const protocol = this._trim(value.substring(0, value.indexOf(":")));
-    const isInvalidProtocol = isProtocolRequired && this.allowedProtocols.indexOf(protocol.toLowerCase()) === -1;
-    if (
-      value !== "/" &&
-      value !== "#" &&
-      value[0] !== "#" &&
-      isInvalidProtocol
-    ) {
+    const isRootUrl = value === '/';
+    const isUrlFragment = /^#/.test(value);
+    const isValidProtocol = !isProtocolRequired || this.allowedProtocols.indexOf(protocol.toLowerCase()) > -1;
+    if (!(isRootUrl || isUrlFragment || isValidProtocol)) {
       return "";
     } else {
       return xss.escapeAttrValue(value);

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,7 +227,8 @@ export class Sanitizer {
    * Sanitizes a URL string following the allowed protocols and sanitization rules.
    *
    * @param {string} value The URL to sanitize.
-   * @returns {string} The sanitized URL.
+   * @param {{ isProtocolRequired: boolean }} options Configuration options for URL checking.
+   * @returns {string} The sanitized URL if it's valid, or an empty string if the URL is invalid.
    */
   public sanitizeUrl(value: string, options?: {
     /** Whether a protocol must exist on the URL for it to be considered valid. Defaults to `true`. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -231,19 +231,22 @@ export class Sanitizer {
    * @returns {string} The sanitized URL if it's valid, or an empty string if the URL is invalid.
    */
   public sanitizeUrl(value: string, options?: {
-    /** Whether a protocol must exist on the URL for it to be considered valid. Defaults to `true`. */
+    /** Whether a protocol must exist on the URL for it to be considered valid. Defaults to `true`. If `false` and the provided URL has no protocol, it will be automatically prefixed with `https://`. */
     isProtocolRequired?: boolean;
   }): string {
     const { isProtocolRequired = true } = options ?? {};
     const protocol = this._trim(value.substring(0, value.indexOf(":")));
     const isRootUrl = value === '/';
     const isUrlFragment = /^#/.test(value);
-    const isValidProtocol = !isProtocolRequired || this.allowedProtocols.indexOf(protocol.toLowerCase()) > -1;
-    if (!(isRootUrl || isUrlFragment || isValidProtocol)) {
-      return "";
-    } else {
+    const isValidProtocol = protocol && this.allowedProtocols.indexOf(protocol.toLowerCase()) > -1;
+
+    if (isRootUrl || isUrlFragment || isValidProtocol) {
       return xss.escapeAttrValue(value);
     }
+    if (!protocol && !isProtocolRequired) {
+      return xss.escapeAttrValue(`https://${value}`);
+    }
+    return "";
   }
 
   /**


### PR DESCRIPTION
**Note**: In testing this and our hyperlink builder, I noticed that the current logic of just checking for `:` in the string allows for invalid URLs like https:::://www.google.com. We probably want to open a separate ticket to fix that. Might be worth installing https://www.npmjs.com/package/is-url-superb as a dependency and then using it under the hood since that package uses the `URL` constructor trick. A simpler fix would be to check how many `:` there are, but there are other ways a URL could be malformed.