### PR TITLE
Remove dependency on lodash.isplainobject

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -368,4 +368,3 @@ A copy of the license is available in the repository's [LICENSE](./LICENSE) file
 ### Dependencies
 
 - [js-xss](https://github.com/leizongmin/js-xss) ([MIT](https://github.com/leizongmin/js-xss#license))
-- [Lodash isPlainObject](https://www.npmjs.com/package/lodash.isplainobject) ([MIT](https://raw.githubusercontent.com/lodash/lodash/4.17.10-npm/LICENSE))

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     ]
   },
   "dependencies": {
-    "lodash.isplainobject": "^4.0.6",
     "xss": "^1.0.13"
   },
   "devDependencies": {
@@ -57,7 +56,6 @@
     "@rollup/plugin-replace": "^4.0.0",
     "@rollup/plugin-typescript": "^8.3.3",
     "@types/jest": "^28.1.6",
-    "@types/lodash.isplainobject": "^4.0.7",
     "jest": "^28.1.3",
     "rimraf": "^3.0.2",
     "rollup": "^2.77.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,12 +6,8 @@
  * http://ucdok.com
  * The MIT License, see
  * https://github.com/leizongmin/js-xss/blob/master/LICENSE for details
- *
- * Lodash/isPlainObject
- * Copyright (c) JS Foundation and other contributors <https://js.foundation/>
- * MIT License, see https://raw.githubusercontent.com/lodash/lodash/4.17.10-npm/LICENSE for details
  * */
-import isPlainObject from "lodash.isplainobject";
+import isPlainObject from "./plainObject";
 import * as xss from "xss";
 
 /**

--- a/src/plainObject.test.ts
+++ b/src/plainObject.test.ts
@@ -1,4 +1,3 @@
-// import ldIsPlainObject from "lodash.isplainobject";
 import isPlainObject from "./plainObject";
 
 describe("isPlainObject", () => {

--- a/src/plainObject.test.ts
+++ b/src/plainObject.test.ts
@@ -49,7 +49,6 @@ describe("isPlainObject", () => {
     expect(isPlainObject(new Set())).toBeFalsy();
     expect(isPlainObject(new WeakSet())).toBeFalsy();
     expect(isPlainObject(Symbol())).toBeFalsy();
-    expect(isPlainObject(Reflect)).toBeFalsy();
     expect(isPlainObject(Foo)).toBeFalsy();
     expect(isPlainObject(Bar)).toBeFalsy();
     expect(isPlainObject(JSON)).toBeFalsy();

--- a/src/plainObject.test.ts
+++ b/src/plainObject.test.ts
@@ -1,0 +1,78 @@
+// import ldIsPlainObject from "lodash.isplainobject";
+import isPlainObject from "./plainObject";
+
+describe("isPlainObject", () => {
+  // @ts-ignore
+  function Foo() {
+    // @ts-ignore
+    this.a = 1;
+  }
+
+  // @ts-ignore
+  const Bar = () => {
+    // @ts-ignore
+    const b = 1;
+  };
+
+  test("Test truthy values", () => {
+    // plain objects
+    expect(isPlainObject({})).toBeTruthy();
+    expect(isPlainObject({ x: 0, y: 0 })).toBeTruthy();
+    expect(isPlainObject({ constructor: Foo })).toBeTruthy();
+    expect(isPlainObject(new Object())).toBeTruthy();
+    expect(isPlainObject(new Object(null))).toBeTruthy();
+    expect(isPlainObject(new Proxy({}, {}))).toBeTruthy();
+
+    // objects with `[[Prototype]]` of `null`
+    const nullPrototypeObj = Object.create(null);
+    expect(isPlainObject(nullPrototypeObj)).toBeTruthy();
+    nullPrototypeObj.prototype = Object.prototype.constructor;
+    expect(isPlainObject(nullPrototypeObj)).toBeTruthy();
+
+    // objects with a `valueOf` property
+    expect(isPlainObject({ valueOf: 0 })).toBeTruthy();
+  });
+  test("Falsey values", () => {
+    // plain objects
+    expect(isPlainObject([1, 2, 3])).toBeFalsy();
+
+    // non-Object objects
+    expect(isPlainObject(Error)).toBeFalsy();
+    expect(isPlainObject(Math)).toBeFalsy();
+    expect(isPlainObject(function* generator() {})).toBeFalsy();
+    expect(
+      isPlainObject({ a: 1, b: 2, __proto__: { b: 3, c: 4 } })
+    ).toBeFalsy();
+    expect(isPlainObject(new Date())).toBeFalsy();
+    expect(isPlainObject(new Map())).toBeFalsy();
+    expect(isPlainObject(new WeakMap())).toBeFalsy();
+    expect(isPlainObject(new Set())).toBeFalsy();
+    expect(isPlainObject(new WeakSet())).toBeFalsy();
+    expect(isPlainObject(Symbol())).toBeFalsy();
+    expect(isPlainObject(Reflect)).toBeFalsy();
+    expect(isPlainObject(Foo)).toBeFalsy();
+    expect(isPlainObject(Bar)).toBeFalsy();
+    expect(isPlainObject(JSON)).toBeFalsy();
+    expect(isPlainObject(new RegExp(""))).toBeFalsy();
+    expect(
+      isPlainObject(
+        new Promise<void>((resolve) => {
+          resolve();
+        })
+      )
+    ).toBeFalsy();
+
+    expect(isPlainObject(new DataView(new ArrayBuffer(0)))).toBeFalsy();
+
+    // non-objects
+    expect(isPlainObject(null)).toBeFalsy();
+    expect(isPlainObject(undefined)).toBeFalsy();
+    expect(isPlainObject(NaN)).toBeFalsy();
+    expect(isPlainObject(Infinity)).toBeFalsy();
+    expect(isPlainObject(true)).toBeFalsy();
+    expect(isPlainObject(false)).toBeFalsy();
+    expect(isPlainObject("")).toBeFalsy();
+    expect(isPlainObject("e")).toBeFalsy();
+    expect(isPlainObject(1)).toBeFalsy();
+  });
+});

--- a/src/plainObject.ts
+++ b/src/plainObject.ts
@@ -1,0 +1,30 @@
+"use strict";
+
+/**
+ * Determine if the value is a plain object.
+ * @param {*} value The value to check.
+ * @returns {boolean} Returns `true` if `value` is a plain object, else `false`.
+ */
+const isPlainObject = (value: any) => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  if (Object.prototype.toString.call(value) !== "[object Object]") {
+    return false;
+  }
+
+  let proto = Object.getPrototypeOf(value);
+
+  if (proto === null) {
+    return true;
+  }
+
+  while (Object.getPrototypeOf(proto) !== null) {
+    proto = Object.getPrototypeOf(proto);
+  }
+
+  return Object.getPrototypeOf(value) === proto;
+};
+
+export default isPlainObject;

--- a/src/plainObject.ts
+++ b/src/plainObject.ts
@@ -1,5 +1,3 @@
-"use strict";
-
 /**
  * Determine if the value is a plain object.
  * @param {*} value The value to check.

--- a/yarn.lock
+++ b/yarn.lock
@@ -958,18 +958,6 @@
     jest-matcher-utils "^28.0.0"
     pretty-format "^28.0.0"
 
-"@types/lodash.isplainobject@^4.0.7":
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/@types/lodash.isplainobject/-/lodash.isplainobject-4.0.7.tgz#698e3231341b1aa0a16681e7aa8b10ee6d9a7d8c"
-  integrity sha512-fdHtdjpy7fXydEaRHx1dPa+2AVmLbmk2Gv7f0w/90BKCH0DkWo8pIrzygnB3rvgo6oKNb3cO9VaPpj9GLCr5Ug==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash@*":
-  version "4.14.170"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.170.tgz#0d67711d4bf7f4ca5147e9091b847479b87925d6"
-  integrity sha512-bpcvu/MKHHeYX+qeEN8GE7DIravODWdACVA1ctevD8CN24RhPZIKMn9ntfAsrvLfSX3cR5RrBKAbYm9bGs0A+Q==
-
 "@types/node@*":
   version "15.12.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.2.tgz#1f2b42c4be7156ff4a6f914b2fb03d05fa84e38d"
@@ -2117,11 +2105,6 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
-
-lodash.isplainobject@^4.0.6:
-  version "4.0.6"
-  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
-  integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
 
 lodash.memoize@4.x:
   version "4.1.2"


### PR DESCRIPTION
### Changes
* feat: Remove dependency on lodash._isPlainObject.

  Adds local implementation of `isPlainObject` as well as unit tests.