### PR TITLE
feat: allow customizing css filter and establish modified defaults

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -635,4 +635,21 @@ describe("Sanitizer", () => {
     });
   });
 
+  test("public css filter", () => {
+    const sanitizer = new Sanitizer();
+    const expectedWhitelist = {
+      ...getDefaultCSSWhiteList(),
+      "flex": true,
+      "flex-basis": true,
+      "flex-direction": true,
+      "flex-flow": true,
+      "flex-grow": true,
+      "flex-shrink": true,
+      "flex-wrap": true,
+      "line-height": true,
+      "overflow": true
+    };
+    expect(sanitizer.arcgisCSSWhiteList).toEqual(expectedWhitelist);
+  });
+
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -93,14 +93,16 @@ describe("Sanitizer", () => {
     expect(sanitizer4.xssFilterOptions).toEqual({ whiteList: { a: [] } });
 
     // Extending the CSS defaults
-    const sanitizer5 = new Sanitizer({ css: { whiteList: { "line-height": false } } }, true);
+    const sanitizer5 = new Sanitizer({ css: { whiteList: { "line-height": false, "align-items": true } } }, true);
     const defaultSanitizer5 = new Sanitizer();
     const defaultOptions5 = Object.create(
       defaultSanitizer5.arcgisFilterOptions
     );
     defaultOptions5.css = getCSSOptions();
     defaultOptions5.css.whiteList["line-height"] = false;
-    expect((sanitizer5.xssFilterOptions.css as any).whiteList["line-height"]).toEqual(false);
+    defaultOptions5.css.whiteList["align-items"] = true;
+    expect((sanitizer5.xssFilterOptions.css as any).whiteList["line-height"]).toBeFalsy();
+    expect((sanitizer5.xssFilterOptions.css as any).whiteList["align-items"]).toBeTruthy();
     expect(sanitizer5.xssFilterOptions).toEqual(defaultOptions5);
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,8 +218,14 @@ export class Sanitizer {
             filterOptions.whiteList || {},
           ]);
         } else if (key === "css") {
-          const cssExtensions = filterOptions[key] instanceof Object ? (filterOptions[key] as ICSSFilter).whiteList ?? {} : {};
-          Object.keys(cssExtensions).forEach((attr) => (xssFilterOptions[key] as ICSSFilter).whiteList[attr] = cssExtensions[attr]);
+          const cssExtensions = (filterOptions.css as ICSSFilter).whiteList;
+          if (cssExtensions != null && filterOptions.css instanceof Object) {
+            Object.keys(cssExtensions).forEach(
+              (attr) =>
+                ((xssFilterOptions.css as ICSSFilter).whiteList[attr] =
+                  cssExtensions[attr])
+            );
+          }
         } else {
           xssFilterOptions[key] = filterOptions[key];
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,8 @@ export class Sanitizer {
       "width",
     ],
   };
-  private readonly arcgisCSSWhiteListOverrides: ICSSWhiteList = {
+  public readonly arcgisCSSWhiteList: ICSSWhiteList = {
+    ...xss.getDefaultCSSWhiteList() as any,
     "flex": true,
     "flex-basis": true,
     "flex-direction": true,
@@ -204,11 +205,9 @@ export class Sanitizer {
       // Override the defaults
       xssFilterOptions = filterOptions;
     } else if (filterOptions && extendDefaults) {
-      const cssWhiteList = this._getArcGISCSSWhiteList();
-
       // Extend the defaults
       xssFilterOptions = Object.create(this.arcgisFilterOptions);
-      xssFilterOptions.css = { whiteList: cssWhiteList };
+      xssFilterOptions.css = { whiteList: this.arcgisCSSWhiteList };
       Object.keys(filterOptions).forEach((key) => {
         if (key === "whiteList") {
           // Extend the whitelist by concatenating arrays
@@ -233,7 +232,7 @@ export class Sanitizer {
       // Only use the defaults
       xssFilterOptions = Object.create(this.arcgisFilterOptions);
       xssFilterOptions.whiteList = this.arcgisWhiteList;
-      xssFilterOptions.css = { whiteList: this._getArcGISCSSWhiteList() };
+      xssFilterOptions.css = { whiteList: this.arcgisCSSWhiteList };
     }
 
     this.xssFilterOptions = xssFilterOptions;
@@ -382,14 +381,6 @@ export class Sanitizer {
         ? `&#x${Number(value.charCodeAt(idx)).toString(16)};`
         : c;
     });
-  }
-
-  private _getArcGISCSSWhiteList() {
-    const cssWhiteList = xss.getDefaultCSSWhiteList();
-    Object.keys(this.arcgisCSSWhiteListOverrides).forEach((key) => {
-      cssWhiteList[key] = this.arcgisCSSWhiteListOverrides[key];
-    });
-    return cssWhiteList;
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,6 @@
 import isPlainObject from "./plainObject";
 import * as xss from "xss";
 
-
 /**
  * The response from the validate method
  *


### PR DESCRIPTION
Sets the default CSS filter to turn on `overflow`, `line-height` and the flexbox options: `flex`, `flex-basis`, `flex-direction`, `flex-flow`, `flex-grow`, `flex-shrink`, `flex-wrap`.

Also added code to ensure that overriding or extending default css whiteList takes our defaults into account. Added tests to ensure that extending defaults and overriding work as intended, as well as to test out the CSS properties enabled by default.