### PR TITLE
fix: enable justify-content in default css whitelist

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -49,7 +49,8 @@ describe("Sanitizer", () => {
     cssWhiteList["flex-shrink"] = true;
     cssWhiteList["flex-wrap"] = true;
     cssWhiteList["line-height"] = true;
-    cssWhiteList["overflow"] = true;
+    cssWhiteList["justify-content"] = true;
+    cssWhiteList["overflow"] = true;    
     return { whiteList: cssWhiteList };
   }
 
@@ -646,6 +647,7 @@ describe("Sanitizer", () => {
       "flex-grow": true,
       "flex-shrink": true,
       "flex-wrap": true,
+      "justify-content": true,
       "line-height": true,
       "overflow": true
     };

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -50,7 +50,7 @@ describe("Sanitizer", () => {
     cssWhiteList["flex-wrap"] = true;
     cssWhiteList["line-height"] = true;
     cssWhiteList["justify-content"] = true;
-    cssWhiteList["overflow"] = true;    
+    cssWhiteList["overflow"] = true;
     return { whiteList: cssWhiteList };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,6 +137,7 @@ export class Sanitizer {
     "flex-shrink": true,
     "flex-wrap": true,
     "line-height": true,
+    "justify-content": true,
     "overflow": true
   };
   public readonly allowedProtocols: string[] = [


### PR DESCRIPTION
Adds `justify-content` as enabled in our default css whitelist.