### PR TITLE
JM/Add support for SVG tags and safe attributes in sanitizer

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -305,6 +305,19 @@ describe("Sanitizer", () => {
     });
   });
 
+  test("preserves per-tag attribute whitelists for safe attributes", () => {
+    const sanitizer = new Sanitizer();
+    const onTagAttr = sanitizer.arcgisFilterOptions.onTagAttr!;
+
+    expect(onTagAttr("div", "title", "not allowed", false)).toBeUndefined();
+    expect(
+      sanitizer.sanitize('<div title="not allowed">Text</div>')
+    ).toBe("<div>Text</div>");
+    expect(
+      sanitizer.sanitize('<path width="24" title="not allowed"></path>')
+    ).toBe("<path></path>");
+  });
+
   test("optionally allow undefined values to pass sanitizer", () => {
     const sanitizer = new Sanitizer();
     // tslint:disable-next-line:no-string-literal

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -595,7 +595,7 @@ describe("Sanitizer", () => {
     expect(sanitizer.sanitize(abbr)).toBe(abbr);
     expect(sanitizer.sanitize(ol)).toBe(ol);
     expect(sanitizer.sanitize(safeDiv)).toBe(safeDiv);
-    expect(sanitizer.sanitize(strippedClass)).toBe('<div>Text content</div>');
+    expect(sanitizer.sanitize(strippedClass)).toBe(strippedDiv);
     expect(sanitizer.sanitize(unsafeDiv)).toBe(strippedDiv);
     expect(sanitizer.sanitize(audio)).toBe(audio);
     expect(sanitizer.sanitize(stripAudioSrc)).toBe(strippedAudioSrc);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -305,17 +305,19 @@ describe("Sanitizer", () => {
     });
   });
 
-  test("preserves per-tag attribute whitelists for safe attributes", () => {
+  test("allows safe attributes on supported tags", () => {
     const sanitizer = new Sanitizer();
     const onTagAttr = sanitizer.arcgisFilterOptions.onTagAttr!;
 
-    expect(onTagAttr("div", "title", "not allowed", false)).toBeUndefined();
+    expect(onTagAttr("div", "title", "allowed", false)).toBe(
+      'title="allowed"'
+    );
     expect(
-      sanitizer.sanitize('<div title="not allowed">Text</div>')
-    ).toBe("<div>Text</div>");
+      sanitizer.sanitize('<div title="allowed" onload="alert(1)">Text</div>')
+    ).toBe('<div title="allowed">Text</div>');
     expect(
-      sanitizer.sanitize('<path width="24" title="not allowed"></path>')
-    ).toBe("<path></path>");
+      sanitizer.sanitize('<path width="24" title="allowed"></path>')
+    ).toBe('<path width="24" title="allowed"></path>');
   });
 
   test("optionally allow undefined values to pass sanitizer", () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -72,6 +72,7 @@ describe("Sanitizer", () => {
       "align-items",
       "align-self",
       "overflow",
+      "row-gap",
     ];
     const cssWhiteList: Record<string, any> = getDefaultCSSWhiteList();
     enabledAttributes.forEach((key) => { cssWhiteList[key] = true});
@@ -226,6 +227,82 @@ describe("Sanitizer", () => {
     expect(sanitizer.sanitize(arguments)).toBe(null);
     expect(sanitizer.sanitize(() => "test")).toBe(null);
     expect(sanitizer.sanitize(new Error("test"))).toBe(null);
+  });
+
+  test("allows SVG tags and safe attributes", () => {
+    const sanitizer = new Sanitizer();
+    const html =
+      '<svg width="24" height="24" onload="alert(1)"><path d="M0 0h24v24H0z" /></svg><script>alert(1)</script><style>body { display: none; }</style>';
+
+    expect(sanitizer.sanitize(html)).toBe(
+      '<svg width="24" height="24"><path d="M0 0h24v24H0z" /></svg>&lt;script&gt;alert(1)&lt;/script&gt;&lt;style&gt;body { display: none; }&lt;/style&gt;'
+    );
+
+    expect(
+      sanitizer.sanitize(
+        '<svg viewBox="not numbers" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg" onload="alert(1)"></svg>'
+      )
+    ).toBe(
+      '<svg viewBox="not numbers" preserveAspectRatio="xMidYMid meet" xmlns="http://www.w3.org/2000/svg"></svg>'
+    );
+
+    const onTagAttr = sanitizer.arcgisFilterOptions.onTagAttr!;
+    expect(
+      onTagAttr(
+        "svg",
+        "viewbox",
+        '0 0 24 24" onload="alert(1)',
+        true
+      )
+    ).toBe('viewBox="0 0 24 24&quot; onload=&quot;alert(1)"');
+    expect(
+      onTagAttr(
+        "svg",
+        "preserveaspectratio",
+        'xMidYMid meet" onload="alert(1)',
+        true
+      )
+    ).toBe(
+      'preserveAspectRatio="xMidYMid meet&quot; onload=&quot;alert(1)"'
+    );
+
+    expect(
+      sanitizer.sanitize(
+        `<svg width='24" onload="alert(1)'><path d='M0 0" onload="alert(1)' /></svg>`
+      )
+    ).toBe(
+      '<svg width="24&quot; onload=&quot;alert(1)"><path d="M0 0&quot; onload=&quot;alert(1)" /></svg>'
+    );
+  });
+
+  test("strips excluded attributes from allowed SVG tags", () => {
+    const sanitizer = new Sanitizer();
+    const excludedAttributes = [
+      {
+        input: '<image href="https://example.com/image.svg"></image>',
+        expected: "<image></image>",
+      },
+      {
+        input: '<use xlink:href="#icon"></use>',
+        expected: "<use></use>",
+      },
+      {
+        input: '<path style="display:none"></path>',
+        expected: "<path></path>",
+      },
+      {
+        input: '<animate begin="0s" end="1s" attributeName="x" from="0" to="1" values="0;1"></animate>',
+        expected: "<animate></animate>",
+      },
+      {
+        input: '<svg xml:base="https://example.com/"></svg>',
+        expected: "<svg></svg>",
+      },
+    ];
+
+    excludedAttributes.forEach(({ input, expected }) => {
+      expect(sanitizer.sanitize(input)).toBe(expected);
+    });
   });
 
   test("optionally allow undefined values to pass sanitizer", () => {
@@ -497,6 +574,7 @@ describe("Sanitizer", () => {
     const abbr = `<abbr title="Cascading Style Sheets">CSS</abbr>`;
     const ol = "<ol><li>List Item 1</li><li>List Item 2</li></ol>";
     const safeDiv = '<div style="display:none;">Text content</div>';
+    const strippedClass = '<div class="content">Text content</div>';
     const unsafeDiv = '<div onerror="alert(1)">Text content</div>';
     const strippedDiv = "<div>Text content</div>";
     const audio = `<audio controls><source src="http://someurl.tld/path/to/audio/file.mp3" type="audio/mpeg"></audio>`;
@@ -517,6 +595,7 @@ describe("Sanitizer", () => {
     expect(sanitizer.sanitize(abbr)).toBe(abbr);
     expect(sanitizer.sanitize(ol)).toBe(ol);
     expect(sanitizer.sanitize(safeDiv)).toBe(safeDiv);
+    expect(sanitizer.sanitize(strippedClass)).toBe('<div>Text content</div>');
     expect(sanitizer.sanitize(unsafeDiv)).toBe(strippedDiv);
     expect(sanitizer.sanitize(audio)).toBe(audio);
     expect(sanitizer.sanitize(stripAudioSrc)).toBe(strippedAudioSrc);
@@ -656,6 +735,8 @@ describe("Sanitizer", () => {
       "flex-grow:1;",
       "flex-shrink:1;",
       "flex-wrap:wrap;",
+      "gap:1rem;",
+      "row-gap:1rem;",
     ];
     flexProperties.forEach((prop) => {
       const value = `<div style="${prop}">Flex property test</div>`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,7 +176,7 @@ export class Sanitizer {
     nav: ["style"],
     ol: [],
     p: ["style"],
-    path: SafeSVGPresentationAttrs,
+    path: SafeSVGPresentationAttrs.slice(),
     pattern: [],
     polygon: SafeSVGPolygonAttrs.concat(SafeSVGPresentationAttrs),
     polyline: SafeSVGPolygonAttrs.concat(SafeSVGPresentationAttrs),

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,86 @@ export interface ISanitizeOptions {
 }
 
 /**
+ * Safe attrs are based on https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.md#xss-prevention-rules-summary
+ */
+// The current entries are considered low risk because they are not URL, CSS, or event attributes.
+// Values bypass normal attribute validation but are escaped before returning the attribute.
+const SafeAttrs = [
+  "align",
+  "alink",
+  "alt",
+  "bgcolor",
+  "border",
+  "cellpadding",
+  "cellspacing",
+  "color",
+  "cols",
+  "colspan",
+  "coords",
+  "d",
+  "dir",
+  "face",
+  "height",
+  "hspace",
+  "ismap",
+  "lang",
+  "marginheight",
+  "marginwidth",
+  "multiple",
+  "nohref",
+  "noresize",
+  "noshade",
+  "nowrap",
+  "ref",
+  "rel",
+  "rev",
+  "rows",
+  "rowspan",
+  "scrolling",
+  "shape",
+  "span",
+  "summary",
+  "tabindex",
+  "title",
+  "usemap",
+  "valign",
+  "value",
+  "vlink",
+  "vspace",
+  "width",
+];
+
+const SafeSVGPresentationAttrs = [
+  "color",
+  "display",
+  "fill-opacity",
+  "font-family",
+  "font-size",
+  "font-style",
+  "font-weight",
+  "opacity",
+  "shape-rendering",
+  "stroke-dasharray",
+  "stroke-dashoffset",
+  "stroke-linecap",
+  "stroke-linejoin",
+  "stroke-miterlimit",
+  "stroke-opacity",
+  "stroke-width",
+  "text-anchor",
+  "text-rendering",
+  "transform",
+  "visibility",
+];
+
+const SafeSVGCircleAttrs = ["cx", "cy", "r"];
+const SafeSVGEllipseAttrs = ["cx", "cy", "rx", "ry"];
+const SafeSVGLineAttrs = ["x1", "x2", "y1", "y2"];
+const SafeSVGPolygonAttrs = ["points"];
+const SafeSVGRectAttrs = ["rx", "ry", "x", "y"];
+const SafeSVGTextAttrs = ["dx", "dy", "x", "y"];
+
+/**
  * The Sanitizer Class
  *
  * @export
@@ -50,24 +130,31 @@ export class Sanitizer {
   public readonly arcgisWhiteList: IWhiteList = {
     a: ["href", "style", "target"],
     abbr: ["title"],
+    animate: [],
+    animatetransform: [],
     article: ["style"],
     aside: ["style"],
     audio: ["autoplay", "controls", "loop", "muted", "preload"],
     b: [],
     blockquote: ["style"],
     br: [],
+    circle: SafeSVGCircleAttrs.concat(SafeSVGPresentationAttrs),
+    clippath: [],
     code: ["style"],
     dd: ["style"],
+    defs: [],
     del: ["style"],
     details: ["open", "style"],
     div: ["align", "aria-hidden", "aria-label", "style"],
     dl: ["style"],
     dt: ["style"],
+    ellipse: SafeSVGEllipseAttrs.concat(SafeSVGPresentationAttrs),
     em: [],
     figcaption: ["style"],
     figure: ["style"],
     font: ["color", "face", "size", "style"],
     footer: ["style"],
+    g: SafeSVGPresentationAttrs.slice(),
     h1: ["style"],
     h2: ["style"],
     h3: ["style"],
@@ -77,21 +164,36 @@ export class Sanitizer {
     header: ["style"],
     hr: [],
     i: [],
+    image: [],
     img: ["alt", "border", "height", "src", "style", "width"],
     li: [],
+    line: SafeSVGLineAttrs.concat(SafeSVGPresentationAttrs),
+    lineargradient: [],
     main: ["style"],
     mark: ["style"],
+    marker: [],
+    mask: [],
     nav: ["style"],
     ol: [],
     p: ["style"],
+    path: SafeSVGPresentationAttrs,
+    pattern: [],
+    polygon: SafeSVGPolygonAttrs.concat(SafeSVGPresentationAttrs),
+    polyline: SafeSVGPolygonAttrs.concat(SafeSVGPresentationAttrs),
     pre: ["style"],
+    radialgradient: [],
+    rect: SafeSVGRectAttrs.concat(SafeSVGPresentationAttrs),
     section: ["style"],
     source: ["media", "src", "type"],
     span: ["aria-hidden", "aria-label", "style"],
+    stop: ["offset", "stop-color", "stop-opacity"],
     strong: [],
     sub: ["style"],
     summary: ["style"],
     sup: ["style"],
+    svg: ["preserveaspectratio", "viewbox", "xmlns"].concat(SafeSVGPresentationAttrs),
+    switch: [],
+    symbol: [],
     table: ["border", "cellpadding", "cellspacing", "height", "style", "width"],
     tbody: [],
     tr: ["align", "height", "style", "valign"],
@@ -115,9 +217,13 @@ export class Sanitizer {
       "valign",
       "width",
     ],
+    text: SafeSVGTextAttrs.concat(SafeSVGPresentationAttrs),
+    textpath: [],
     time: ["style"],
+    tspan: SafeSVGTextAttrs.concat(SafeSVGPresentationAttrs),
     u: [],
     ul: [],
+    use: [],
     video: [
       "autoplay",
       "controls",
@@ -161,7 +267,8 @@ export class Sanitizer {
     "justify-items": true,
     "justify-self": true,
     "line-height": true,
-    "overflow": true
+    "overflow": true,
+    "row-gap": true
   };
   public readonly allowedProtocols: string[] = [
     "http",
@@ -193,6 +300,23 @@ export class Sanitizer {
   ];
   public readonly arcgisFilterOptions: XSS.IFilterXSSOptions = {
     allowCommentTag: true,
+    onTagAttr: (_tag: string, name: string, value: string): string | void => {
+      // js-xss lowercases attribute names, so restore case-sensitive SVG names.
+      if (_tag === "svg") {
+        if (name === "viewbox") {
+          return `viewBox="${xss.escapeAttrValue(value)}"`;
+        }
+        if (name === "preserveaspectratio") {
+          return `preserveAspectRatio="${xss.escapeAttrValue(value)}"`;
+        }
+      }
+      // These low-risk attributes bypass normal value filtering, but escaping is
+      // still required to prevent their values from creating new attributes.
+      if (SafeAttrs.indexOf(name) > -1) {
+        return `${name}="${xss.escapeAttrValue(value)}"`;
+      }
+      return;
+    },
     safeAttrValue: (
       tag: string,
       name: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,7 +176,7 @@ export class Sanitizer {
     nav: ["style"],
     ol: [],
     p: ["style"],
-    path: SafeSVGPresentationAttrs.slice(),
+    path: ["d"].concat(SafeSVGPresentationAttrs),
     pattern: [],
     polygon: SafeSVGPolygonAttrs.concat(SafeSVGPresentationAttrs),
     polyline: SafeSVGPolygonAttrs.concat(SafeSVGPresentationAttrs),
@@ -191,7 +191,13 @@ export class Sanitizer {
     sub: ["style"],
     summary: ["style"],
     sup: ["style"],
-    svg: ["preserveaspectratio", "viewbox", "xmlns"].concat(SafeSVGPresentationAttrs),
+    svg: [
+      "height",
+      "preserveaspectratio",
+      "viewbox",
+      "width",
+      "xmlns",
+    ].concat(SafeSVGPresentationAttrs),
     switch: [],
     symbol: [],
     table: ["border", "cellpadding", "cellspacing", "height", "style", "width"],
@@ -300,7 +306,15 @@ export class Sanitizer {
   ];
   public readonly arcgisFilterOptions: XSS.IFilterXSSOptions = {
     allowCommentTag: true,
-    onTagAttr: (_tag: string, name: string, value: string): string | void => {
+    onTagAttr: (
+      _tag: string,
+      name: string,
+      value: string,
+      isWhiteAttr: boolean
+    ): string | void => {
+      if (!isWhiteAttr) {
+        return;
+      }
       // js-xss lowercases attribute names, so restore case-sensitive SVG names.
       if (_tag === "svg") {
         if (name === "viewbox") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -306,15 +306,7 @@ export class Sanitizer {
   ];
   public readonly arcgisFilterOptions: XSS.IFilterXSSOptions = {
     allowCommentTag: true,
-    onTagAttr: (
-      _tag: string,
-      name: string,
-      value: string,
-      isWhiteAttr: boolean
-    ): string | void => {
-      if (!isWhiteAttr) {
-        return;
-      }
+    onTagAttr: (_tag: string, name: string, value: string): string | void => {
       // js-xss lowercases attribute names, so restore case-sensitive SVG names.
       if (_tag === "svg") {
         if (name === "viewbox") {


### PR DESCRIPTION
## Summary

This expands the package defaults to support safe SVG markup and common low-risk HTML attributes taken from `sanitizerUtils.ts` in `@arcgis/core` , and Dashboards (particularly SVG).

The default whitelist now includes additional SVG elements, with attribute lists tailored to each element. Common low-risk attributes such as `width`, `height`, `d`, `preserveAspectRatio`, and `xmlns` are also preserved with escaped values. Case-sensitive SVG names such as `viewBox` and `preserveAspectRatio` are restored after `js-xss` lowercases them.

Tests cover the newly allowed SVG markup, rejected event attributes, escaped attribute values, and `viewBox` casing.

## Need for a Unified HTML Sanitizer
A unified HTML sanitizer is essential to provide a consistent, secure, and predictable experience across all applications.

1. **Consistent user experience across applications**
HTML sanitization is currently overridden in several applications, leading to inconsistent behavior. For example, Popups supports a different set of SVG tags than applications like Dashboard. As a result, the same content may render correctly in one application but fail or be stripped in another, creating an uneven user experience.
2. **Stronger guardrails for AI-generated content**
As we increasingly rely on AI to generate content, it is critical to have a centralized sanitization layer that acts as a security guardrail. A unified HTML sanitizer helps ensure that AI-generated content is consistently validated and sanitized before rendering, reducing the risk of introducing unsafe or unsupported HTML.
3. **Standardized content through CKEditor**
CKEditor can enforce a common set of allowed HTML tags and attributes across all applications. Aligning the editor configuration with a unified sanitizer ensures that users can only create content that is supported everywhere, eliminating discrepancies between authoring and rendering.

## What is not included

SVG attributes are explicitly allowlisted, so resource references, CSS, event handlers, animation values, and `xml:base` remain blocked.

These additions apply to every default `new Sanitizer()` instance. Sanitizers created with custom options that replace the defaults are unchanged.

## What sanitizerUtils.ts would still be responsible for

- For rendered content, removes unsupported tags while keeping their text, and removes `script` and `style` elements together with their contents. This package default escapes unsupported tags and their contents instead.

	```ts
	{
	  stripIgnoreTag: true, // remove unsupported tags but keep their text
	  stripIgnoreTagBody: ["script", "style"], // remove these tags and their contents
	}
	```

- For plain text output, removes every HTML tag except an attribute-free `<br>`. This package does not include that behavior.

	```ts
	{
	  whiteList: { br: [] }, // allow only <br> without attributes
	  stripIgnoreTag: true, // remove every other tag but keep its text
	}
	```